### PR TITLE
Remove Deface override on order details page

### DIFF
--- a/app/overrides/spree/admin/orders/_shipment/stock_contents.html.erb.deface
+++ b/app/overrides/spree/admin/orders/_shipment/stock_contents.html.erb.deface
@@ -1,2 +1,0 @@
-<!-- replace_contents  '.stock-contents tbody' -->
-<%= render 'stock_contents', shipment: shipment %>


### PR DESCRIPTION
The Deface override is breaking on Solidus 2.4. The javascript fails to
register events on the button elements in the shipment manifest table.

Remove the Deface override so that the split shipment button can be
used.